### PR TITLE
🐛 fix: 랭킹 좌측 UI 렌더링 오류 수정

### DIFF
--- a/src/components/ranking/rankingLeft/bottom/list-bottomRanking.jsx
+++ b/src/components/ranking/rankingLeft/bottom/list-bottomRanking.jsx
@@ -2,19 +2,26 @@ import * as s from "../../../../styles/ranking/ranking";
 import ItemBottomRanking from "./item-bottomRanking";
 
 const ListBottomRanking = ({ data }) => {
-    const slicedData = data.slice(3); 
+    const slicedData = data.slice(3);
 
     return (
-        <s.ListBottomContainer>
-            {slicedData.map((item, index) => (
-                <ItemBottomRanking 
-                    key={index}
-                    id={item.id}
-                    username={item.username}
-                />
-            ))}
-        </s.ListBottomContainer>
-    )
-}
+        <>
+            {slicedData.length > 0 ? (
+                <s.ListBottomContainer>
+                    {slicedData.map((item, index) => (
+                        <ItemBottomRanking 
+                            key={index}
+                            id={item.id}
+                        />
+                    ))}
+                </s.ListBottomContainer>
+            ) : (
+                <s.ListBottomContainer2>
+                    <s.ErrorP>랭킹 정보가 없습니다.</s.ErrorP>
+                </s.ListBottomContainer2>
+            )}
+        </>
+    );
+};
 
 export default ListBottomRanking;

--- a/src/components/ranking/rankingLeft/rankingLeft.jsx
+++ b/src/components/ranking/rankingLeft/rankingLeft.jsx
@@ -3,33 +3,25 @@ import * as s from "../../../styles/ranking/ranking";
 import ListTopRanking from "./top/list-topRanking";
 import ListBottomRanking from "./bottom/list-bottomRanking";
 
-
-
 const RankingLeft = ({ data }) => {
     const [sortedData, setSortedData] = useState([]);
 
     useEffect(() => {
-        if (data) {
+        if (Array.isArray(data)) {
             const sorted = [...data].sort((a, b) => b.id - a.id);
             setSortedData(sorted);
         }
     }, [data]);
 
-    if (!sortedData.length) {
-        return null;
-    }
-
     return (
         <s.LeftContainer>
             <ListTopRanking data={sortedData} />
-
             <s.BottomBar />
-
             <s.BottomContainer>
                 <ListBottomRanking data={sortedData} />
             </s.BottomContainer>
         </s.LeftContainer>
     );
-}
+};
 
 export default RankingLeft;

--- a/src/components/ranking/rankingLeft/top/list-topRanking.jsx
+++ b/src/components/ranking/rankingLeft/top/list-topRanking.jsx
@@ -1,25 +1,32 @@
 import * as s from "../../../../styles/ranking/ranking";
 import ItemTopRanking from "./item-topRanking";
 
-
 const ListTopRanking = ({ data }) => {
     const topData = data.slice(0, 3);
 
     return (
         <s.ListTopContainer>
             <s.ListTopP>[이 달 랭]</s.ListTopP>
-            <s.ListTopInnerContainer>
-            {topData.map((item, index) => (
-                <ItemTopRanking 
-                    key={index}
-                    id={item.id} 
-                    username={item.username}
-                    rank={index + 1}
-                />
-            ))}
-            </s.ListTopInnerContainer>
+            
+            {topData.length > 0 ? (
+                <s.ListTopInnerContainer>
+                    {topData.map((item, index) => (
+                        <ItemTopRanking 
+                            key={index}
+                            id={item.id} 
+                            username={item.username}
+                            rank={index + 1}
+                        />
+                    ))}
+                </s.ListTopInnerContainer>
+            ) : (
+                <s.ListTopInnerContainer2>
+                    <s.ErrorP>랭킹 정보가 없습니다.</s.ErrorP>
+                </s.ListTopInnerContainer2>
+            )}
+            
         </s.ListTopContainer>
-    )
-}
+    );
+};
 
 export default ListTopRanking;

--- a/src/styles/ranking/ranking.js
+++ b/src/styles/ranking/ranking.js
@@ -74,6 +74,21 @@ export const ListTopInnerContainer = styled.div`
     grid-template-columns: repeat(3, 1fr);
 `
 
+export const ListTopInnerContainer2 = styled.div`
+    width: 100%;
+    display: flex;
+    text-align: center;
+    margin-top: 9vw;
+`
+
+export const ErrorP = styled.p`
+    width: 100%;
+    font-size: 1vw;
+    font-weight: 400;
+    color: ${colors.sideBarGray2};
+    opacity: 0.5;
+`
+
 // item-topRanking.jsx
 export const ItemTopContainer = styled.div`
     width: 100%;
@@ -162,6 +177,13 @@ export const ListBottomContainer = styled.div`
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     margin-top: 1vw;
+`
+
+export const ListBottomContainer2 = styled.div`
+    width: 100%;
+    display: flex;
+    text-align: center;
+    margin-top: 6vw;
 `
 
 // item-bottomRanking.jsx


### PR DESCRIPTION
## 🚀 관련 이슈
- close #100 

## 🔑 작업 내용
랭킹페이지 좌측 UI가 통신실패 시 렌더링 되지 않는 오류 수정

## 📷 스크린샷
<img width="1512" alt="스크린샷 2025-02-06 오전 1 21 30" src="https://github.com/user-attachments/assets/a88b50dd-3e61-48ed-be98-f6f3c622fcc8" />

## 🌐 공유 사항 to 리뷰어
우선 통신 부분은 신경쓰지 않고 구현했습니다.

## 🚨 이슈 사항
