### PR TITLE
✨ feat: 캘린더 전체 일정 보기 api 연결 및 ui 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fontsource/do-hyeon": "^5.1.1",
         "@hookform/resolvers": "^3.10.0",
-        "@tanstack/react-query": "^5.62.16",
+        "@tanstack/react-query": "^5.66.6",
         "axios": "^1.7.9",
         "buffer": "^6.0.3",
         "html2canvas": "^1.4.1",
@@ -1212,9 +1212,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.64.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.2.tgz",
-      "integrity": "sha512-hdO8SZpWXoADNTWXV9We8CwTkXU88OVWRBcsiFrk7xJQnhm6WRlweDzMD+uH+GnuieTBVSML6xFa17C2cNV8+g==",
+      "version": "5.66.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.66.4.tgz",
+      "integrity": "sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1222,12 +1222,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.64.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.2.tgz",
-      "integrity": "sha512-3pakNscZNm8KJkxmovvtZ4RaXLyiYYobwleTMvpIGUoKRa8j8VlrQKNl5W8VUEfVfZKkikvXVddLuWMbcSCA1Q==",
+      "version": "5.66.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.66.6.tgz",
+      "integrity": "sha512-Xepc53h+D5sqoO/MZiSH2ROVLTDfRwR+3E4C2oS71/lo9u2mwbneZIEyIGXEHvmfyQpqtbf9voghD+QwLDLzcA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.64.2"
+        "@tanstack/query-core": "5.66.4"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@fontsource/do-hyeon": "^5.1.1",
     "@hookform/resolvers": "^3.10.0",
-    "@tanstack/react-query": "^5.62.16",
+    "@tanstack/react-query": "^5.66.6",
     "axios": "^1.7.9",
     "buffer": "^6.0.3",
     "html2canvas": "^1.4.1",

--- a/src/components/calender/calenderLeft/calenderLeft.jsx
+++ b/src/components/calender/calenderLeft/calenderLeft.jsx
@@ -1,8 +1,11 @@
-import React, { useState } from "react";
-import * as s from "../../../styles/calender/calender";
-import CalenderButton from "../../../assets/images/calender/button.png";
+import React, { useState } from 'react';
+import * as s from '../../../styles/calender/calender';
+import CalenderButton from '../../../assets/images/calender/button.png';
+import useFetch from '../../../hooks/useFetch';
+import { useSchedules } from '../../../hooks/useSchedules';
 
 const CalenderLeft = ({ selectedDay, setSelectedDay }) => {
+  const { data, loading, error } = useFetch(`/schedule`);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [year, setYear] = useState(currentDate.getFullYear());
   const [month, setMonth] = useState(currentDate.getMonth());
@@ -16,6 +19,15 @@ const CalenderLeft = ({ selectedDay, setSelectedDay }) => {
     });
   };
 
+  const scheduleMap = data
+    ?.sort((a, b) => new Date(a.date_time) - new Date(b.date_time))
+    .reduce((acc, item) => {
+      const dateKey = item.date_time.split('T')[0];
+      if (!acc[dateKey]) acc[dateKey] = [];
+      acc[dateKey].push(item.location);
+      return acc;
+    }, {});
+
   const generateCalendar = () => {
     const firstDayOfMonth = new Date(year, month, 1);
     const lastDayOfMonth = new Date(year, month + 1, 0);
@@ -28,7 +40,11 @@ const CalenderLeft = ({ selectedDay, setSelectedDay }) => {
     const dates = [];
 
     // 이전 달
-    for (let i = prevMonthLastDay - prevMonthDays + 1; i <= prevMonthLastDay; i++) {
+    for (
+      let i = prevMonthLastDay - prevMonthDays + 1;
+      i <= prevMonthLastDay;
+      i++
+    ) {
       dates.push({
         day: i,
         currentMonth: false,
@@ -66,12 +82,16 @@ const CalenderLeft = ({ selectedDay, setSelectedDay }) => {
   const calendarDates = generateCalendar();
 
   const handleDateClick = (day, month, year) => {
-    const formattedDate = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    const formattedDate = `${year}-${String(month).padStart(2, '0')}-${String(
+      day
+    ).padStart(2, '0')}`;
     setSelectedDay(formattedDate);
   };
 
   const isSelected = (day, month, year) => {
-    const formattedDate = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    const formattedDate = `${year}-${String(month).padStart(2, '0')}-${String(
+      day
+    ).padStart(2, '0')}`;
     return selectedDay === formattedDate;
   };
 
@@ -83,33 +103,64 @@ const CalenderLeft = ({ selectedDay, setSelectedDay }) => {
             {year}년 {month + 1}월
           </s.CalenderP2>
           <s.ButtonContainer>
-            <s.ButtonImg src={CalenderButton} alt="button" onClick={() => changeMonth(-1)} />
-            <s.ButtonImg src={CalenderButton} alt="button" style={{ rotate: "180deg" }} onClick={() => changeMonth(1)} />
+            <s.ButtonImg
+              src={CalenderButton}
+              alt="button"
+              onClick={() => changeMonth(-1)}
+            />
+            <s.ButtonImg
+              src={CalenderButton}
+              alt="button"
+              style={{ rotate: '180deg' }}
+              onClick={() => changeMonth(1)}
+            />
           </s.ButtonContainer>
         </s.Header>
 
         <s.WeekContainer>
-          {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
+          {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((day) => (
             <s.Day key={day}>{day}</s.Day>
           ))}
         </s.WeekContainer>
 
         <s.DateContainer>
           {calendarDates.map((date, index) => {
-            const { day, month: cellMonth, year: cellYear, currentMonth } = date;
+            const {
+              day,
+              month: cellMonth,
+              year: cellYear,
+              currentMonth,
+            } = date;
+            const formattedDate = `${cellYear}-${String(cellMonth).padStart(
+              2,
+              '0'
+            )}-${String(day).padStart(2, '0')}`;
+            const locationInfo = scheduleMap?.[formattedDate];
             const lastrow = index >= calendarDates.length - 7;
             const selected = isSelected(day, cellMonth, cellYear);
 
             return (
               <s.DateCell
                 key={index}
-                className={currentMonth ? "" : "inactive"}
-                onClick={() => currentMonth && handleDateClick(day, cellMonth, cellYear)}
+                className={currentMonth ? '' : 'inactive'}
+                onClick={() =>
+                  currentMonth && handleDateClick(day, cellMonth, cellYear)
+                }
                 lastrow={lastrow.toString()}
                 selected={selected}
               >
-                {selected && <s.SelectedDateCell lastrow={lastrow.toString()} />}
+                {selected && (
+                  <s.SelectedDateCell lastrow={lastrow.toString()} />
+                )}
                 {day}
+                {currentMonth && locationInfo && (
+                  <s.LocationList>
+                    {(locationInfo || []).slice(0, 3).map((location, idx) => (
+                      <s.DateText key={idx}>{location}</s.DateText>
+                    ))}
+                    {locationInfo.length > 3 && <s.MoreInfo>...</s.MoreInfo>}
+                  </s.LocationList>
+                )}
               </s.DateCell>
             );
           })}

--- a/src/components/calender/calenderRight/addModal.jsx
+++ b/src/components/calender/calenderRight/addModal.jsx
@@ -4,6 +4,7 @@ import colors from '../../../styles/common/colors';
 import Trash from '../../../assets/images/calender/trash.png';
 import ModalTime from './modalTime';
 import { API } from '../../../apis/axios';
+import { useAddSchedule } from '../../../hooks/useSchedules';
 
 const AddModal = ({ onClose, selectedDay }) => {
   const [period, setPeriod] = useState('오전');

--- a/src/components/calender/calenderRight/editModal.jsx
+++ b/src/components/calender/calenderRight/editModal.jsx
@@ -118,6 +118,7 @@ const EditModal = ({ onClose, selectedDay, id }) => {
       });
       if (response) {
         alert('일지 삭제 완료');
+        onClose();
       }
     } catch (err) {
       console.log('error', err);

--- a/src/hooks/useSchedules.js
+++ b/src/hooks/useSchedules.js
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { API } from '../apis/axios';
+
+// 일정 조회
+export const useSchedules = () => {
+  return useQuery({
+    queryKey: ['schedules'],
+    queryFn: async () => {
+      const response = await API.get('/schedule');
+      return response.data;
+    },
+  });
+};
+
+// 일정 세부 일정 조회
+export const useDaySchedules = (selectedDay) => {
+  return useQuery({
+    queryKey: ['schedules', selectedDay],
+    queryFn: async () => {
+      const response = await API.get(`/schedule/${selectedDay}`);
+      return response.data;
+    },
+  });
+};
+
+// 일정 추가
+export const useAddSchedule = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (newSchedule) => {
+      const response = await API.post('/schedule', newSchedule);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['schedules'] });
+    },
+  });
+};

--- a/src/styles/calender/calender.js
+++ b/src/styles/calender/calender.js
@@ -1,5 +1,5 @@
-import styled from "styled-components";
-import colors from "../common/colors";
+import styled from 'styled-components';
+import colors from '../common/colors';
 
 // calender.jsx
 export const CalenderContainer = styled.div`
@@ -101,7 +101,7 @@ export const DateContainer = styled.div`
 
 export const DateCell = styled.div`
   width: 100%;
-  height: ${(props) => (props.lastrow === "true" ? "3.75vw" : "6.6vw")};
+  height: ${(props) => (props.lastrow === 'true' ? '3.75vw' : '6.6vw')};
   text-align: center;
   cursor: pointer;
   font-size: 1vw;
@@ -117,7 +117,7 @@ export const DateCell = styled.div`
 
 export const SelectedDateCell = styled.div`
   position: absolute;
-  top: ${(props) => (props.lastrow === "true" ? "15%" : "8%")};
+  top: ${(props) => (props.lastrow === 'true' ? '15%' : '8%')};
   left: 50%;
   transform: translate(-50%, -50%);
   width: 1.5vw;
@@ -131,7 +131,7 @@ export const ListP = styled.p`
   font-size: 0.55vw;
   font-weight: 300;
   color: ${colors.black};
-`
+`;
 
 // calenderRight.jsx
 export const CalenderRightContainer = styled.div`
@@ -180,120 +180,120 @@ export const ModalContainer = styled.div`
   bottom: 3.15vw;
 `;
 
-
 // list-calender.jsx
 export const ListContainer = styled.div`
-    width: 100%;
-    max-height: 27.85vw;
-    overflow-y: scroll;
-    border: 0.05vw solid ${colors.calenderGray};
+  width: 100%;
+  max-height: 27.85vw;
+  overflow-y: scroll;
+  border: 0.05vw solid ${colors.calenderGray};
 `;
 
 export const TitleContainer = styled.div`
-    width: 100%;
-    height: 2.15vw;
-    background: ${({ editvisible }) => (editvisible === "true" ? colors.subMain : colors.white)};
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    cursor: pointer;
-    margin-top: 1.2vw;
-    border: 0.05vw solid ${colors.calenderGray};
-    border-bottom: none;
+  width: 100%;
+  height: 2.15vw;
+  background: ${({ editvisible }) =>
+    editvisible === 'true' ? colors.subMain : colors.white};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  margin-top: 1.2vw;
+  border: 0.05vw solid ${colors.calenderGray};
+  border-bottom: none;
 `;
 
 export const TitleInnerContainer = styled.div`
-    width: 90%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  width: 90%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 export const LeftContainer = styled.div`
-    width: calc(100% - 3vw);
-    display: flex;
-    align-items: center;
+  width: calc(100% - 3vw);
+  display: flex;
+  align-items: center;
 `;
 
 export const TitleP = styled.p`
-    width: 25%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 0.9vw;
-    font-weight: 600;
-    color: ${colors.black};
+  width: 25%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.9vw;
+  font-weight: 600;
+  color: ${colors.black};
 `;
 
 export const TitleP2 = styled(TitleP)`
-    font-size: 0.5vw;
-    width: 100%;
-    padding-right: 1vw;
+  font-size: 0.5vw;
+  width: 100%;
+  padding-right: 1vw;
 `;
 
 export const EditButton = styled.button`
-    width: 3vw;
-    height: 1.3vw;
-    background: ${colors.homeGray};
-    border: none;
-    border-radius: 0.25vw;
-    font-size: 0.8vw;
-    font-weight: 500;
-    color: ${colors.calenderGray4};
-    cursor: pointer;
-    display: ${({ visible }) => (visible === "true" ? "inline-block" : "none")};
+  width: 3vw;
+  height: 1.3vw;
+  background: ${colors.homeGray};
+  border: none;
+  border-radius: 0.25vw;
+  font-size: 0.8vw;
+  font-weight: 500;
+  color: ${colors.calenderGray4};
+  cursor: pointer;
+  display: ${({ visible }) => (visible === 'true' ? 'inline-block' : 'none')};
 `;
 
 // item-calender.jsx
 export const ItemContainer = styled.div`
-    width: 100%;
-    height: 3.5vw;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-bottom: 0.05vw solid ${colors.calenderGray};
-    background: ${({ selected }) => (selected ? colors.subMain : "transparent")};
-    cursor: pointer;
-`
+  width: 100%;
+  height: 3.5vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-bottom: 0.05vw solid ${colors.calenderGray};
+  background: ${({ selected }) => (selected ? colors.subMain : 'transparent')};
+  cursor: pointer;
+`;
 
 export const ItemInnerContainer = styled.div`
-    width: 90%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-`
+  width: 90%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 export const ItemP = styled.p`
-    font-size: 1.2vw;
-    font-weight: 500;
-    color: ${colors.black};
-    width: 25%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`
+  font-size: 1.2vw;
+  font-weight: 500;
+  color: ${colors.black};
+  width: 25%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 export const ItemP2 = styled(ItemP)`
-    font-size: 0.8vw;
-    width: 100%;
-    padding-right: 1vw;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`
+  font-size: 0.8vw;
+  width: 100%;
+  padding-right: 1vw;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 export const EditButton2 = styled.button`
-    width: 3vw;
-    height: 1.3vw;
-    background: ${colors.homeGray};
-    border: none;
-    border-radius: 0.25vw;
-    font-size: 0.8vw;
-    font-weight: 500;
-    color: ${colors.calenderGray4};
-    cursor: pointer;
-    display: ${({ selected }) => (selected ? "inline-block" : "none")};
-`
+  width: 3vw;
+  height: 1.3vw;
+  background: ${colors.homeGray};
+  border: none;
+  border-radius: 0.25vw;
+  font-size: 0.8vw;
+  font-weight: 500;
+  color: ${colors.calenderGray4};
+  cursor: pointer;
+  display: ${({ selected }) => (selected ? 'inline-block' : 'none')};
+`;
 
 // placeModal.jsx
 export const PlaceModalContainer = styled.div`
@@ -307,20 +307,20 @@ export const PlaceModalContainer = styled.div`
   justify-content: center;
   gap: 0.3vw;
   background: ${colors.calenderGray5};
-`
+`;
 
 export const PlaceTitleContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
-`
+`;
 
 export const PlaceTitleP = styled.p`
   font-size: 0.9vw;
   font-weight: 700;
   color: ${colors.sideBarGray2};
-`
+`;
 
 export const TrashImg = styled.img`
   width: 0.85vw;
@@ -336,7 +336,7 @@ export const PlaceInput = styled.input`
   font-size: 0.8vw;
   font-weight: 500;
   color: ${colors.sideBarGray2};
-`
+`;
 
 export const PlaceButton = styled.button`
   width: 9.6vw;
@@ -347,58 +347,58 @@ export const PlaceButton = styled.button`
   font-size: 0.8vw;
   font-weight: 700;
   color: ${colors.white};
-`
+`;
 
 // modalTime.jsx
 export const SelectBox = styled.div`
-    position: relative;
-    width: 2.85vw;
-    height: 1.65vw;
-    background: ${colors.white};
-    border-radius: 0.25vw;
-    padding: 0 0.3vw;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    cursor: pointer;
-    font-size: 0.8vw;
-    font-weight: 700;
-    color: ${colors.sideBarGray2};
+  position: relative;
+  width: 2.85vw;
+  height: 1.65vw;
+  background: ${colors.white};
+  border-radius: 0.25vw;
+  padding: 0 0.3vw;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  font-size: 0.8vw;
+  font-weight: 700;
+  color: ${colors.sideBarGray2};
 `;
 
 export const SelectToggle = styled.img`
-    width: 0.35vw;
-    height: 0.35vw;
-`
+  width: 0.35vw;
+  height: 0.35vw;
+`;
 
 export const Dropdown = styled.div`
-    position: absolute;
-    top: 100%;
-    left: 0;
-    width: 100%;
-    max-height: 6.35vw;
-    overflow-y: auto;
-    background: ${colors.calenderGray6};
-    border-radius: 0 0 0.25vw 0.25vw;
-    z-index: 100;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 6.35vw;
+  overflow-y: auto;
+  background: ${colors.calenderGray6};
+  border-radius: 0 0 0.25vw 0.25vw;
+  z-index: 100;
 
-    &::-webkit-scrollbar {
-        display: none;
-    }
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 `;
 
 export const Option = styled.div`
-    width: 100%;
-    height: 1.75vw;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    cursor: pointer;
-    font-size: 0.8vw;
-    font-weight: 700;
-    color: ${colors.sideBarGray2};
+  width: 100%;
+  height: 1.75vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.8vw;
+  font-weight: 700;
+  color: ${colors.sideBarGray2};
 `;
 
 // addModal.jsx, editModal.jsx
@@ -472,4 +472,31 @@ export const AddButton = styled.button`
   &:hover {
     background: ${colors.mainDark};
   }
+`;
+
+export const DateText = styled.div`
+  font-size: 0.56vw;
+  font-weight: 500;
+  color: ${colors.black};
+  text-align: left;
+  max-width: 4.7vw;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const LocationList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1vw;
+  margin-top: 0.3vw;
+  margin-left: 3vw;
+  max-width: 4.7vw;
+`;
+
+export const MoreInfo = styled.div`
+  font-size: 0.8vw;
+  font-weight: 800;
+  color: #555555;
 `;


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) ✨ feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #141 

## 🔑 작업 내용
- 캘린더 전체 일정 보기 api 연결했습니다.
- 일정이 4개 이상일때, 최대 3개까지만 표시하고 ... 처리했습니다.
- 일정 추가시 시간대 기준 오름 차순 정렬되어 표시되도록 처리했습니다.
- 여행지 이름이 길어질때 text-overflow: ellipsis 처리 했습니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/0f9b5925-9afd-46c3-9399-7d2af07688ff)

## 🌐 공유 사항 to 리뷰어
- 동적 랜더링 하려고 tanstackQuery 라이브러리 설치했습니다. pull 받으시고 npm install 하십쇼.
- 아직 tanstackQuery 연결을 하지 못했습니다. hook은 만들었으니 여유있다면 연결 부탁드립니다.
- UTC -> KSC 차이로 인해, 오전 일정이 추가되면 전 날 일정으로 추가됩니다. 하루종일 붙잡았는데 해결 못했습니다. 한번씩 확인 부탁드립니다.

## 🚨 이슈 사항
<!-- 이슈가 발생하는 부분이 있다면 적어주세요 -->