### PR TITLE
🎨 Design: sideBar css 수정

### DIFF
--- a/src/styles/common/sidebar/sidebar.js
+++ b/src/styles/common/sidebar/sidebar.js
@@ -49,16 +49,21 @@ export const ProfileImgContainer = styled.img`
 `
 
 export const PContainer = styled.div`
+    width: 90%;
     display: flex;
     flex-direction: column;
     text-align: center;
 `
 
 export const ProfileP = styled.p`
+    width: 100%;
     text-align: center;
     font-size: ${(props) => props.size || '0.7vw'};
     font-weight: ${(props) => props.weight || '300'};
     color: ${colors.black};
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 `
 
 export const ListContainer = styled.div`


### PR DESCRIPTION
## 🚀 관련 이슈
- close #186 

## 🔑 작업 내용
sideBar의 profile에 나오는 문구가 길어지게 되면 UI가 깨지는 오류 해결했습니다.

## 📷 스크린샷
**- width보다 길어지면 ... 으로 보이게 처리**
<img width="457" alt="스크린샷 2025-02-21 오전 2 17 23" src="https://github.com/user-attachments/assets/c9c8cf20-eccf-4453-be4b-8b7b4712fb1e" />

## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항
